### PR TITLE
Update the code to Pharo 9

### DIFF
--- a/src/BaselineOfHashtable/BaselineOfHashtable.class.st
+++ b/src/BaselineOfHashtable/BaselineOfHashtable.class.st
@@ -20,7 +20,8 @@ BaselineOfHashtable >> baseline: spec [
 			spec
 				package: 'HashtableToPharo8' with: [ spec requires: #( 'Hashtable' ) ];
 				package: 'Hashtable'.
-			spec group: #default with: #( 'HashtableToPharo8' ) ] ].
+			spec
+				group: 'Core' with: #( 'HashtableToPharo8' 'Hashtable' ) ] ].
 
 	"Groups"
 	spec

--- a/src/BaselineOfHashtable/BaselineOfHashtable.class.st
+++ b/src/BaselineOfHashtable/BaselineOfHashtable.class.st
@@ -16,7 +16,7 @@ BaselineOfHashtable >> baseline: spec [
 			package: 'Hashtable';
 			package: 'Hashtable-Tests' with: [ spec requires: #( 'Hashtable' ) ].
 
-		spec for: #( #'pharo3.x' #'pharo4.x' #'pharo5.x' #'pharo6.x' #'pharo7.x' ) do: [ 
+		spec for: #( #'pharo3.x' #'pharo4.x' #'pharo5.x' #'pharo6.x' #'pharo7.x' #'pharo8.x') do: [ 
 			spec
 				package: 'HashtableToPharo8' with: [ spec requires: #( 'Hashtable' ) ];
 				package: 'Hashtable'.

--- a/src/BaselineOfHashtable/BaselineOfHashtable.class.st
+++ b/src/BaselineOfHashtable/BaselineOfHashtable.class.st
@@ -9,19 +9,23 @@ Class {
 
 { #category : #baseline }
 BaselineOfHashtable >> baseline: spec [
+
 	<baseline>
+	spec for: #common do: [ "Packages"
+		spec
+			package: 'Hashtable';
+			package: 'Hashtable-Tests' with: [ spec requires: #( 'Hashtable' ) ].
+
+		spec for: #( #'pharo3.x' #'pharo4.x' #'pharo5.x' #'pharo6.x' #'pharo7.x' ) do: [ 
+			spec
+				package: 'HashtableToPharo8' with: [ spec requires: #( 'Hashtable' ) ];
+				package: 'Hashtable'.
+			spec group: #default with: #( 'HashtableToPharo8' ) ] ].
+
+	"Groups"
 	spec
-		for: #common
-		do: [
-			"Packages"
-			spec
-				package: 'Hashtable';
-				package: 'Hashtable-Tests' with: [ spec requires: #('Hashtable') ].
-				
-			"Groups"
-			spec
-				group: 'Core' with: #('Hashtable');
-				group: 'Tests' with: #('Hashtable-Tests') ]
+	group: 'Core' with: #( 'Hashtable' );
+	group: 'Tests' with: #( 'Hashtable-Tests' ) 
 ]
 
 { #category : #accessing }

--- a/src/Hashtable/HashTable.class.st
+++ b/src/Hashtable/HashTable.class.st
@@ -332,7 +332,7 @@ HashTable >> keysSortedSafely [
 	sortedKeys sortBlock:
 		[:x :y |  "Should really be use <obj, string, num> compareSafely..."
 			[ x < y ]
-				ifError: [x printString < y printString] ].
+				onErrorDo: [x printString < y printString] ].
 	self keysDo: [ :each | sortedKeys add: each].
 	^ sortedKeys
 ]

--- a/src/HashtableToPharo8/HashTable.extension.st
+++ b/src/HashtableToPharo8/HashTable.extension.st
@@ -2,6 +2,7 @@ Extension { #name : #HashTable }
 
 { #category : #'*HashtableToPharo8' }
 HashTable >> keysSortedSafely [
+	"This method is override in version before Pharo8 to ensure compatibility from Pharo 8"
 	"Answer a SortedCollection containing the receiver's keys."
 	| sortedKeys |
 	sortedKeys := SortedCollection new: self size.

--- a/src/HashtableToPharo8/HashTable.extension.st
+++ b/src/HashtableToPharo8/HashTable.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #HashTable }
+
+{ #category : #'*HashtableToPharo8' }
+HashTable >> keysSortedSafely [
+	"Answer a SortedCollection containing the receiver's keys."
+	| sortedKeys |
+	sortedKeys := SortedCollection new: self size.
+	sortedKeys sortBlock:
+		[:x :y |  "Should really be use <obj, string, num> compareSafely..."
+			[ x < y ]
+				ifError: [x printString < y printString] ].
+	self keysDo: [ :each | sortedKeys add: each].
+	^ sortedKeys
+]

--- a/src/HashtableToPharo8/package.st
+++ b/src/HashtableToPharo8/package.st
@@ -1,0 +1,1 @@
+Package { #name : #HashtableToPharo8 }


### PR DESCRIPTION
This PR aims to replace the code of `Hashtable>>#keysSortedSafely` to replace the deprecated keyword `#ifError:` by `#onErrorDo:`

To ensure compatibility with the older Pharo versions (the current stable included), I have proposed to create a package `HashtableToPharo8` that overrides the method with the old way to execute the code.
This package is loaded only in old pharo version. Thus, the package is not dirty in the last version.
I also have added a comment in the "override method" before P9 to explain it.

Maybe groups can be better managed?
I'm ready for reviews.

fix #3 